### PR TITLE
Add three-button touchscreen controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,6 +2,29 @@ body {
   background-color: #232323;
 }
 
+#game {
+  display: block;
+  margin: 0 auto;
+  position: relative;
+  width: 1260px;
+  height: 640px;
+}
+
+/* Overlay over the game, but be invisible */
+#touch-controls {
+  z-index: 5;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: row;
+}
+#touch-controls div {
+  flex: 1;
+}
+
 #myCanvas {
   /*border-bottom: 1px solid white;*/
   /*-webkit-animation-duration: 1s;

--- a/index.html
+++ b/index.html
@@ -10,8 +10,19 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
   </head>
   <body>
-    <canvas id="myCanvas" width="1260" height= "640">
-    </canvas>
+
+    <section id="game">
+
+      <aside id="touch-controls">
+        <div data-action="move-left"></div>
+        <div data-action="fire" style="flex: 3;"></div>
+        <div data-action="move-right"></div>
+      </aside>
+
+      <canvas id="myCanvas" width="1260" height= "640">
+      </canvas>
+
+    </section>
 
   <script type="text/javascript" src="js/script.js"></script>
   </body>

--- a/js/script.js
+++ b/js/script.js
@@ -16,6 +16,7 @@ var fighter, figherTwo, fighterThree;
 
 function setupGame() {
   $('#gameOver').remove();
+  $('#touch-controls').show();
   canvasAnimation('animated fadeInDown');
 
   speedFactor = 2;
@@ -169,6 +170,7 @@ function win() {
     if (win) {
         clearInterval(window.begin);
         $('body').append($($winAlert));
+        $('#touch-controls').hide();
         $('#gameOver').click(function(){ setupGame(); });
       }
 };
@@ -342,6 +344,15 @@ function redraw() {
     };
 }
 
+function fireBullet() {
+  if (fighter.alive == true) {
+    var bullet = new LaserBullet(530, fighter.x-5, 3, 10, "red", 23.5, 0, -5);
+    bullets.push(bullet);
+    var bullet = new LaserBullet(530, fighter.x+5, 3, 10, "red", 23.5, 0, -5);
+    bullets.push(bullet);
+  }
+}
+
 $(document).ready(function() {
 
     if (!canvas.getContext) {
@@ -373,4 +384,50 @@ $(document).ready(function() {
             rightpressed = false;
         }
     });
+
+    /***************************
+     * Register touch controls */
+    var bulletInterval; // recurs while holding "fire"
+
+    $('#touch-controls').on('touchstart', function(e) {
+      e.preventDefault();
+
+      var action = e.target.dataset.action;
+      switch (action) {
+        case 'move-left':
+          leftpressed = true;
+          rightpressed = false;
+          break;
+        case 'move-right':
+          leftpressed = false;
+          rightpressed = true;
+          break;
+        case 'fire':
+          if (!bulletInterval) {
+            fireBullet(); // now
+            bulletInterval = setInterval(fireBullet, 200); // and later
+          }
+          break;
+      }
+    });
+
+    $('#touch-controls').on('touchend', function(e) {
+      var action = e.target.dataset.action;
+      switch (action) {
+        case 'move-left':
+          leftpressed = false;
+          break;
+        case 'move-right':
+          rightpressed = false;
+          break;
+        case 'fire':
+          if (bulletInterval) {
+            clearInterval(bulletInterval);
+            bulletInterval = null;
+          }
+          break;
+      }
+    });
+
+
 });


### PR DESCRIPTION
Places three invisible touch areas over the game, with the center (fire) being largest. Rigs the controls up to the movement, and the fire control to an interval calling fireBullet (which was extracted from the keyboard controls).

Temporary demo: http://apt.danopia.net/
